### PR TITLE
Fix update_toppers handling in register screen

### DIFF
--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -46,8 +46,12 @@ export class RegisterComponent implements OnInit {
   ngOnInit() {
     this.socketService
       .getSocketConnection()
-      .on('update_toppers', totalTopppers => {
-        this.onlineCount = totalTopppers;
+      .on('update_toppers', data => {
+        if (typeof data === 'number') {
+          this.onlineCount = data;
+        } else if (data && data.toppers) {
+          this.onlineCount = data.toppers.length;
+        }
       });
 
     this.socketService.getSocketConnection().on('update_me', data => {


### PR DESCRIPTION
## Summary
- handle different payloads from `update_toppers` event

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: tslint not found)*