### PR TITLE
Add unit test for SocketService hex color generation

### DIFF
--- a/src/app/socket.service.spec.ts
+++ b/src/app/socket.service.spec.ts
@@ -1,0 +1,8 @@
+import { SocketService } from './socket.service';
+
+describe('SocketService.generateHex', () => {
+  it('should return a hex color string', () => {
+    const hex = SocketService.generateHex();
+    expect(hex).toMatch(/^#[0-9A-F]{6}$/);
+  });
+});


### PR DESCRIPTION
## Summary
- add `socket.service.spec.ts` to test `SocketService.generateHex`

## Testing
- `npm test` *(fails: `ng` not found)*