### PR TITLE
Fix event handling bugs and cleanup

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -31,8 +31,8 @@ function FindAddStack(room: string, currentStack): Datastructure.TopperStack {
 }
 
 io.on('connection', function(client) {
-  // Send current user list to current user only
-  client.emit('update_toppers', totalToppers);
+  // Send current user count to the connecting client only
+  client.emit('total_toppers', totalToppers);
 
   client.on('addUser', function(data: Datastructure.ITopper) {
     data.id = client.id;

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -3,7 +3,8 @@ import {
   AfterViewChecked,
   ElementRef,
   ViewChild,
-  OnInit
+  OnInit,
+  OnDestroy
 } from '@angular/core';
 
 import { SocketService } from '../socket.service';
@@ -29,7 +30,7 @@ import { Chat } from '../../../Datastructure/Message';
     'b { color: #2e69c9; }'
   ]
 })
-export class ChatComponent implements OnInit, AfterViewChecked {
+export class ChatComponent implements OnInit, AfterViewChecked, OnDestroy {
   @ViewChild('chatwindow') private myScrollContainer: ElementRef;
 
   private previousChatHeight: number = 0;
@@ -50,6 +51,10 @@ export class ChatComponent implements OnInit, AfterViewChecked {
     this.socketService.getSocketConnection().on('message', data => {
       this.messages.push(data);
     });
+  }
+
+  ngOnDestroy() {
+    this.socketService.getSocketConnection().off('message');
   }
 
   sendMessage(event) {

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { SocketService } from '../socket.service';
 import { Datastructure } from '../../../Datastructure/TopperStack';
 import { Router } from '@angular/router';
@@ -26,7 +26,7 @@ import { Router } from '@angular/router';
     </div>
 <router-outlet></router-outlet>`,
 })
-export class RegisterComponent implements OnInit {
+export class RegisterComponent implements OnInit, OnDestroy {
   currentTopper: Datastructure.ITopper;
   usernameInvalid: boolean = false;
   onlineCount: number = 0;
@@ -38,17 +38,21 @@ export class RegisterComponent implements OnInit {
   }
 
   addUser() {
+    if (!this.currentTopper.name) {
+      this.usernameInvalid = true;
+      return;
+    }
     this.socketService
       .getSocketConnection()
       .emit('addUser', this.currentTopper);
   }
 
   ngOnInit() {
-    this.socketService
-      .getSocketConnection()
-      .on('update_toppers', totalTopppers => {
-        this.onlineCount = totalTopppers;
-      });
+      this.socketService
+        .getSocketConnection()
+        .on('total_toppers', total => {
+          this.onlineCount = total;
+        });
 
     this.socketService.getSocketConnection().on('update_me', data => {
       this.currentTopper.id = data.id;
@@ -59,5 +63,12 @@ export class RegisterComponent implements OnInit {
       this.currentTopper.id = data.id;
       this.usernameInvalid = true;
     });
+  }
+
+  ngOnDestroy() {
+    const socket = this.socketService.getSocketConnection();
+    socket.off('total_toppers');
+    socket.off('update_me');
+    socket.off('register_failed');
   }
 }

--- a/src/app/top-main/top-main.component.ts
+++ b/src/app/top-main/top-main.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Datastructure } from '../../../Datastructure/TopperStack';
 import { SocketService } from '../socket.service';
 import { Router } from '@angular/router';
@@ -48,7 +48,7 @@ import { Router } from '@angular/router';
     <router-outlet></router-outlet>`,
   styles: ['#topperList { padding:0px; margin-top:0px; }'],
 })
-export class TopMainComponent implements OnInit {
+export class TopMainComponent implements OnInit, OnDestroy {
   socketService: SocketService;
   currentTopper: Datastructure.ITopper;
   topperList: Datastructure.TopperStack = new Datastructure.TopperStack([]);
@@ -66,6 +66,10 @@ export class TopMainComponent implements OnInit {
     this.socketService.getSocketConnection().on('update_toppers', data => {
       this.topperList.setList(data.toppers);
     });
+  }
+
+  ngOnDestroy() {
+    this.socketService.getSocketConnection().off('update_toppers');
   }
 
   topMe() {


### PR DESCRIPTION
## Summary
- use a separate `total_toppers` event for user counts
- validate user names on registration
- remove socket listeners when components are destroyed

## Testing
- `npm run lint` *(fails: `tslint: not found`)*
- `npm run test` *(fails: `ng: not found`)*